### PR TITLE
Replace end of file links with inline links

### DIFF
--- a/Basics/Git.md
+++ b/Basics/Git.md
@@ -1,12 +1,12 @@
 ## 1. Preface
 
-![Git][image-1]
+![Git](http://imgs.xkcd.com/comics/git.png)
 
 **Thou shalt use 2FA everywhere where we use Git!**
 
 ## 2. SSH keys
 
-Before you start with Git, we encourage you to [connect to GitHub][1] or Bitbucket with SSH keys. First of all, you need to [generate a public/private SSH key pair][2], then add the public part to GitHub and Bitbucket accounts. 
+Before you start with Git, we encourage you to [connect to GitHub](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) or Bitbucket with SSH keys. First of all, you need to [generate a public/private SSH key pair](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent), then add the public part to GitHub and Bitbucket accounts. 
 
 Using SSH key you’ll be able to manage (clone, push, pull..) private repositories without entering your email/username password each time you need to perform an operation on the remote repository.
 
@@ -47,25 +47,25 @@ When writing commit messages we should stick to these 7 rules:
 5. Use the imperative mood in the subject line
 6. Wrap the body at 72 characters
 7. Use the body to explain what and why vs. how
-8. You can find more details about those in [this blog post][3].
+8. You can find more details about those in [this blog post](https://chris.beams.io/posts/git-commit/).
 
-There is also a [git hook][4] available to validate your commit message.
+There is also a [git hook](https://github.com/m1foley/fit-commit) available to validate your commit message.
 
 ## 6. Pull requests
 
 The preferred way of merging a branch back into `master` is by creating a pull request and assigning it to a colleague for review. At least one person should review any code that is going to be merged (reviewer on PR).
 
-Each PR should have a description. Link to the Productive/Jira task is minimum for description. It would be great to include a link to design (if applicable) and describe the changes that PR introduces. You can find a good read on what the description should contain [here][5].
+Each PR should have a description. Link to the Productive/Jira task is minimum for description. It would be great to include a link to design (if applicable) and describe the changes that PR introduces. 
 
 PR should have an assignee, which is usually a person who created a PR or the person who will be responsible for merging it. 
 
 Master and/or release branches should always be marked as protected on Github in order to prevent direct push to those branches. Next options should be checked on the branch protection rules page on Github:
 * ***Require pull request reviews before merging***
-![Pull request][image-2]
+![Pull request](/img/iOS-pull-request.png)
 * ***Require status check to pass before merging (this includes Bitrise CI and/or SonarCloud if used)***
-![Status chec][image-3]
+![Status chec](/img/iOS-status-check.png)
 * ***Require branches to be up to date before merging***
-![Branches][image-4]
+![Branches](/img/iOS-branches-up-to-date.png)
 
 ## 7. Mobile specific
 
@@ -73,7 +73,7 @@ Above mentioned rules should be the minimum for all platforms. Few more are spec
 
 ### Git Flow/Infinum Flow
 
-We’ll be using the Git Flow standard as a base for git branching with some modifications. More about Git Flow [here][6].
+We’ll be using the Git Flow standard as a base for git branching with some modifications. More about Git Flow [here](https://nvie.com/posts/a-successful-git-branching-model/).
 
 #### Branches
 We’ll be using **master** as the main branch. Since we’ll be using tags and optionally **release** branches for deployment, **develop** branch becomes redundant and therefore should not be used in the project.
@@ -104,10 +104,10 @@ The main branches in this flow are:
   * Example usage: there is a bug on app version 1.2.0. In that case you checkout to a commit tagged with v1.2.0. You create release/1.2.1 branch from that tag, and you create hotfix/whatever from that branch where you implement the fix and create PR back to the release/1.2.1 branch
  
 #### Pull requests
-Each pull request must have an automatic check - running tests or just building the app if your project doesn’t have tests. Setup on GitHub is described in general rules of this handbook, while on how to set up Bitrise Checks on projects you have [Android][7] and [iOS][8] handbook chapters.
+Each pull request must have an automatic check - running tests or just building the app if your project doesn’t have tests. Setup on GitHub is described in general rules of this handbook, while on how to set up Bitrise Checks on projects you have [Android](https://infinum.com/handbook/books/android/bitrise) and [iOS](https://infinum.com/handbook/books/ios/bitrise-ci/pull-request-ci-check) handbook chapters.
 
 #### Deployment
-Deployment is done via tags and Bitrise CI/CD. Here are the chapters on setting up Bitrise on your project: [Android][7] and [iOS][9].
+Deployment is done via tags and Bitrise CI/CD. Here are the chapters on setting up Bitrise on your project: [Android](https://infinum.com/handbook/books/android/bitrise) and [iOS](https://infinum.com/handbook/books/ios/bitrise-ci/general-intro).
 
 Sync with another platform as much as possible. Few stuff that should be defined and synced:
 * Environment names - staging, production, uat, beta… whatever is convention on project, but should be the same. Exception probably will be iOS with its production and app store environments due to technical limitations. If using TryOutApps, please sync environment names.
@@ -116,19 +116,3 @@ Sync with another platform as much as possible. Few stuff that should be defined
   * Each project will have different environments so this will be heavily project dependent, but some suggestions: tags should have prefix like ***internal-staging/***, ***internal-production/***, ***appstore/***... Due to limitation on tag triggers on Bitrise, tags with multiple / are not permitted, so you should use something like ***internal-production/***, ***internal-staging/***.
   * Use ***internal-*** prefix for all tags which will trigger internal builds on TryoutApps. The reason behind it: internal tags are not so relevant and one should clear internal tags from time to time to keep the project clean.
   * All the production versions that have been published to the app/play store should be tagged with one extra tag in order to have a better overview of released versions. Tag should look like this: ***v1.2.3*** (without build number).
-
-[1]:  https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh
-[2]:  https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
-[3]:  https://chris.beams.io/posts/git-commit/
-[4]:  https://github.com/m1foley/fit-commit
-[5]:  https://infinum.com/handbook/books/rails/git-process#github-pull-request-descriptions
-[6]:  https://nvie.com/posts/a-successful-git-branching-model/
-[7]:  https://infinum.com/handbook/books/android/bitrise
-[8]:  https://infinum.com/handbook/books/ios/bitrise-ci/pull-request-ci-check
-[9]:  https://infinum.com/handbook/books/ios/bitrise-ci/general-intro
-[10]: https://github.com/infinum/app-deploy-script
-
-[image-1]:	http://imgs.xkcd.com/comics/git.png "Git"
-[image-2]:	/img/iOS-pull-request.png
-[image-3]:	/img/iOS-status-check.png
-[image-4]:	/img/iOS-branches-up-to-date.png

--- a/Basics/Naming.md
+++ b/Basics/Naming.md
@@ -62,7 +62,7 @@ Since _Swift 3_, all function parameters have labels unless you request otherwis
     employees.remove(x) // unclear: are we removing x?
     ```
 
-* When the first argument forms a part of a [prepositional phrase][3], give it an argument label. The argument label should begin at the preposition.
+* When the first argument forms a part of a [prepositional phrase](https://en.wikipedia.org/wiki/Adpositional_phrase#Prepositional_phrases),  give it an argument label. The argument label should begin at the preposition.
     ##### Preferred:
 
     ```swift
@@ -79,7 +79,7 @@ Since _Swift 3_, all function parameters have labels unless you request otherwis
     names.indexOf("Taylor")
     color.fade(fromRed: b, green: c, blue: d) // The first two arguments represent parts of a single abstraction
     ```
-* Please visit [Swift API Design Guidelines][2] for more info and examples on function naming—they provide a lot of examples and explanations on edge cases.
+* Please visit [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) for more info and examples on function naming—they provide a lot of examples and explanations on edge cases.
 
 ## Enumerations
 
@@ -148,9 +148,4 @@ import SomeModule
 let myClass = MyModule.UsefulClass()
 ```
 
-This guide is mostly copied from [Swift API Design Guidelines][2], [Ray Wenderlich Swift guide][1], and [What's new in Swift 3.0][4], with some minor changes.
-
-[1]:    https://github.com/raywenderlich/swift-style-guide#naming
-[2]:    https://swift.org/documentation/api-design-guidelines/
-[3]:    https://en.wikipedia.org/wiki/Adpositional_phrase#Prepositional_phrases
-[4]:    https://www.hackingwithswift.com/swift3
+This guide is mostly copied from [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/), [Ray Wenderlich Swift guide](https://github.com/raywenderlich/swift-style-guide#naming), and [What's new in Swift 3.0](https://www.hackingwithswift.com/swift3), with some minor changes.

--- a/Networking/Apiary and API call mocking.md
+++ b/Networking/Apiary and API call mocking.md
@@ -108,7 +108,7 @@ Some of the Apiary limitations:
 
 At this moment setup is done and you should end up with something like this:
  
-![Editor][image-1]
+![Editor](/img/iOS-apiary-editor.png)
 
 [ 1 ] = Base URL
 
@@ -176,5 +176,3 @@ And that should be it. Your app is ready for some mocking!
 ## Closing words
 
 There is much more Apiary can offer you. This chapter covers only basic, however, there is also a paid version that provides much more functionality. You can find more info [here](https://apiary.io/how-apiary-works).
-
-[image-1]: /img/iOS-apiary-editor.png

--- a/Networking/Networking and working with a RESTful API.md
+++ b/Networking/Networking and working with a RESTful API.md
@@ -3,10 +3,10 @@
 </div>
 
 ## Networking
-For comunication with a remote server, use [Alamofire][1] - an HTTP networking [pod][4] written in Swift. On the off chance that you're actually starting an Objective-C based project, you'll be working with [AFNetworking][2] instead. Both of these libraries are developed by the same team who is responsible for [nshipster.com][3]—a site you should really keep in your bookmarks.
+For comunication with a remote server, use [Alamofire](https://github.com/Alamofire/Alamofire) - an HTTP networking [pod](https://cocoapods.org/) written in Swift. On the off chance that you're actually starting an Objective-C based project, you'll be working with [AFNetworking](https://github.com/AFNetworking/AFNetworking) instead. Both of these libraries are developed by the same team who is responsible for [nshipster.com](http://nshipster.com/)—a site you should really keep in your bookmarks.
 
 ## REST API and services
-In almost all cases, the architecture of the web service your app is communicating with will be implemented using a RESTful architecture style. A simple and easy explanation of REST APIs can be found [here][5]. You can go [here][6] for a more theoretical description of REST.
+In almost all cases, the architecture of the web service your app is communicating with will be implemented using a RESTful architecture style. A simple and easy explanation of REST APIs can be found [here](http://searchsoa.techtarget.com/definition/REST). You can go [here](https://en.wikipedia.org/wiki/Representational_state_transfer) for a more theoretical description of REST.
 
 When communicating with a RESTful API, it's quite easy to separate networking into services, which is precisely what we do. Services are PONSOs (plain old NSObject) that handle all API requests for one particular segment of the API. Here's an example of a service which handles a login action using Alamofire:
 
@@ -101,10 +101,3 @@ struct LotoResult {
     let extraNumber: Int?
 }
 ```
-
-[1]:	https://github.com/Alamofire/Alamofire
-[2]:	https://github.com/AFNetworking/AFNetworking
-[3]:	http://nshipster.com/
-[4]:	https://cocoapods.org/
-[5]:	hhttp://searchsoa.techtarget.com/definition/REST
-[6]:	ttps://en.wikipedia.org/wiki/Representational_state_transfer

--- a/Project flow/App Store pre-submission checklist.md
+++ b/Project flow/App Store pre-submission checklist.md
@@ -59,7 +59,7 @@
 * Screen layout can handle the double-height status bar (e.g., during a phone call)
 * Landscape mode, if supported, looks well-designed (i.e., is not accidental and bad)
 
-You can find more information about this topic [here][1].
+You can find more information about this topic [here](https://developer.apple.com/ios/human-interface-guidelines/overview/design-principles/).
 
 ## iPad-specific
 
@@ -86,5 +86,3 @@ You can find more information about this topic [here][1].
 * The required-device-capabilities entry in the info.plist file match the requirements of the app
 * Your app matches your claimed OS version compatibility
 * NSZombieEnabled is set to NO
-
-[1]:	https://developer.apple.com/ios/human-interface-guidelines/overview/design-principles/

--- a/Project flow/Certificates, provisioning profiles and APNS.md
+++ b/Project flow/Certificates, provisioning profiles and APNS.md
@@ -9,7 +9,7 @@ If you haven't created it then, you can do it now. The process is pretty straigh
 1. Open up the Keychain Access app.
 2. From the menu, select Keychain Access -> Certificate Assistant -> Request a Certificate from the Certificate Authority.
 3. Populate the necessary fields in the Certificate Assistant dialog and choose to save the request to disk.
-4. Go to [developer.apple.com][1] in your favorite browser.
+4. Go to [developer.apple.com](https://developer.apple.com) in your favorite browser.
 5. Log into the Member Center.
 6. Go to Certificates, Identifiers & Profiles -> Certificates.
 7. Under Certificates—Development, choose to add a new development profile (hint: the magic plus sign [+]).
@@ -19,7 +19,7 @@ If you haven't created it then, you can do it now. The process is pretty straigh
 
 You can find it in the Keychain app in the "My Certificates" section.
 
-![Personal certificate][image-1]
+![Personal certificate](/img/iOS-certificates-keychain.png)
 
 The main part of the certificate is your public/private key pair, which is a guarantee that the apps are truly developed/distributed by you.
 
@@ -73,7 +73,7 @@ TestFlight is another common way of sending the builds directly to clients. You 
 For the iOS platform, push notifications are available through the APNS server. You also need SSL certificates to communicate with the APNS server. They can be generated using the developer portal under the "Certificates" section. You will probably need both the development and the production APNS certificates.
 
 
-![APNS Dev certificate][image-2]
+![APNS Dev certificate](/img/iOS-certificates-apns.png)
 
 
 The attached image displays the generation of an APNS development certificate. After continuing, you should select the App ID for the target app and upload the certificate signing request. Again, the process is the same as with generating a personal certificate:
@@ -88,8 +88,3 @@ After completing the CSR upload, save the APNS SSL certificate to disk (you can 
 Generating APNS Production certificates is very similar. All you have to do is choose "Production" under "Certificates" and choose the Apple Push Notification service SSL (Production) in the "Select type" step. The following steps are the same as for the Sandbox SSL certificate generation.
 
 The certificates will be used by the API, which will be responsible for initiating push notification messages.
-
-[1]:	https://developer.apple.com
-
-[image-1]:	/img/iOS-certificates-keychain.png
-[image-2]:	/img/iOS-certificates-apns.png

--- a/Project flow/Custom xcconfigs.md
+++ b/Project flow/Custom xcconfigs.md
@@ -315,8 +315,5 @@ __Build a project :)__
 ## Resources
 
 - [Sample Project](/resources/Sample_xcconfig.zip)
-- [Using xcconfig Files for Your Xcode Project][1]
-- [Generating Xcode Build Configuration Files with BuildSettingExtractor (xcodeproj → xcconfig)][2]
-
-[1]:	http://www.jontolof.com/cocoa/using-xcconfig-files-for-you-xcode-project/
-[2]:	http://jamesdempsey.net/2015/01/31/generating-xcode-build-configuration-files-with-buildsettingextractor-xcodeproj-to-xcconfig/
+- [Using xcconfig Files for Your Xcode Project](http://www.jontolof.com/cocoa/using-xcconfig-files-for-you-xcode-project/)
+- [Generating Xcode Build Configuration Files with BuildSettingExtractor (xcodeproj → xcconfig)](http://jamesdempsey.net/2015/01/31/generating-xcode-build-configuration-files-with-buildsettingextractor-xcodeproj-to-xcconfig/)


### PR DESCRIPTION
Handbook backend has an issue where end-of-file links will not load/show up properly, and they have recommended moving to inline links. In this PR I've moved all end-of-file links to inline ones.